### PR TITLE
Docker Cleanup and Stability Changes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,21 +212,21 @@ task buildSparkBaseImage(type: DockerBuildImage) {
     dependsOn buildDist
 
     inputDir = file('docker/images/docker-spark/base')
-    tag = 'scality/clueso-spark-base:hadoop2.8'
+    tag = 'scality/clueso-spark-base:latest'
 }
 
 task buildSparkMasterImage(type: DockerBuildImage) {
     dependsOn buildSparkBaseImage
 
     inputDir = file('docker/images/docker-spark/master')
-    tag = 'scality/clueso-spark-master:hadoop2.8'
+    tag = 'scality/clueso-spark-master:latest'
 }
 
 task buildSparkWorkerImage(type: DockerBuildImage) {
     dependsOn buildSparkBaseImage
 
     inputDir = file('docker/images/docker-spark/worker')
-    tag = 'scality/clueso-spark-worker:hadoop2.8'
+    tag = 'scality/clueso-spark-worker:latest'
 }
 
 

--- a/build.gradle
+++ b/build.gradle
@@ -234,7 +234,7 @@ task buildLivyImage(type: DockerBuildImage) {
     dependsOn buildSparkBaseImage
 
     inputDir = file('docker/images/clueso-docker-livy')
-    tag = 'scality/clueso-livy:0.4.0'
+    tag = 'scality/clueso-livy:latest'
 }
 
 task buildDocker() {

--- a/docker/images/clueso-docker-livy/entrypoint.sh
+++ b/docker/images/clueso-docker-livy/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e -o pipefail
 
 # s3 secret credentials for Zenko
 if [ -r /run/secrets/s3-credentials ] ; then
@@ -16,4 +17,16 @@ else
   export LIBPROCESS_IP=$HOST
 fi
 
+# wait for Spark master before starting livy
+echo "Waiting for Spark Master to launch on 7077..."
+
+while ! nc -z spark-master 7077 &> /dev/null; do   
+  sleep 1 # wait for 1 second before check again
+done
+
+echo "Spark Master Ready"
+sleep 3
+echo "Starting Livy Server"
+
+# start Livy
 $LIVY_APP_PATH/bin/livy-server $@

--- a/docker/images/clueso-docker-livy/entrypoint.sh
+++ b/docker/images/clueso-docker-livy/entrypoint.sh
@@ -17,11 +17,18 @@ else
   export LIBPROCESS_IP=$HOST
 fi
 
-# exit if spark-master is not ready
-if [ ! nc -z spark-master 7077 &> /dev/null ]; then
-  echo "Cannot contact spark-master on 7077"
-  exit 1
-fi
+# Wait for spark master
+# This allows clean startup
+RETRY=15
+echo "Waiting for spark master"
+while ! nc -z spark-master 7077 &>/dev/null ; do
+  RETRY=$((RETRY-1))
+  if [ $RETRY == 0 ]; then
+    echo "Cannot contact spark master on 7077"
+    exit 1
+  fi
+  sleep 1
+done
 
 echo "Starting Livy Server"
 # start Livy

--- a/docker/images/clueso-docker-livy/entrypoint.sh
+++ b/docker/images/clueso-docker-livy/entrypoint.sh
@@ -17,16 +17,12 @@ else
   export LIBPROCESS_IP=$HOST
 fi
 
-# wait for Spark master before starting livy
-echo "Waiting for Spark Master to launch on 7077..."
+# exit if spark-master is not ready
+if [ ! nc -z spark-master 7077 &> /dev/null ]; then
+  echo "Cannot contact spark-master on 7077"
+  exit 1
+fi
 
-while ! nc -z spark-master 7077 &> /dev/null; do   
-  sleep 1 # wait for 1 second before check again
-done
-
-echo "Spark Master Ready"
-sleep 3
 echo "Starting Livy Server"
-
 # start Livy
 $LIVY_APP_PATH/bin/livy-server $@

--- a/docker/images/docker-spark/base/Dockerfile
+++ b/docker/images/docker-spark/base/Dockerfile
@@ -10,13 +10,11 @@ ENV SPARK_VERSION 2.1.1_2.11
 # once spark is packaged with hadoop 2.8 we can stop compiling
 # https://issues.apache.org/jira/browse/HADOOP-12963
 RUN apt-get update \
-    && apt-get install -y supervisor curl build-essential \
-    python git maven --no-install-recommends \
+    && apt-get install -y curl netcat supervisor curl \
+    build-essential python git maven --no-install-recommends \
     && mkdir -p /var/log/supervisor \
     && curl --retry 6 \
     -fSL https://www.apache.org/dist/hadoop/common/hadoop-$HADOOP_VERSION/hadoop-$HADOOP_VERSION.tar.gz -o /tmp/hadoop.tar.gz \
-    && apt-get install -y supervisor curl --no-install-recommends \
-    && mkdir -p /var/log/supervisor \
     && tar -xvf /tmp/hadoop.tar.gz -C /opt/ \
     && rm /tmp/hadoop.tar.gz \
     && mkdir -p /apps/build/ \
@@ -41,5 +39,6 @@ COPY clueso /clueso
 RUN mkdir -p /clueso/heapdumps && mkdir -p /clueso/conf/
 COPY application.conf /clueso/conf/
 COPY conf /spark/conf/ 
-
+## Java DNS caching setting to prevent inter-container communication issues
+RUN echo 'networkaddress.cache.ttl=20' >> $JAVA_HOME/jre/lib/security/java.security
 CMD bash

--- a/docker/images/docker-spark/master/Dockerfile
+++ b/docker/images/docker-spark/master/Dockerfile
@@ -6,12 +6,14 @@ WORKDIR /
 
 # Install S3 client
 RUN apt-get update && \
-    apt-get install -y cron python-pip && \
-    pip install boto3
+    apt-get install -y cron python-pip supervisor && \
+    pip install boto3 && \
+    mkdir -p /var/log/supervisor 
 
 ADD crontab /etc/cron.d/compactor-cron
 RUN (crontab -l; cat /etc/cron.d/compactor-cron | crontab; crontab -l)
 
+COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 COPY master.sh /
 COPY runTasks.py /
 

--- a/docker/images/docker-spark/master/Dockerfile
+++ b/docker/images/docker-spark/master/Dockerfile
@@ -1,4 +1,4 @@
-FROM scality/clueso-spark-base:hadoop2.8
+FROM scality/clueso-spark-base:latest
 
 HEALTHCHECK CMD curl -f http://localhost:8080/ || exit 1
 
@@ -6,14 +6,13 @@ WORKDIR /
 
 # Install S3 client
 RUN apt-get update && \
-    apt-get install -y cron python-pip supervisor && \
-    pip install boto3 && \
-    mkdir -p /var/log/supervisor 
+    apt-get install -y cron python-pip && \
+    pip install boto3
 
 ADD crontab /etc/cron.d/compactor-cron
 RUN (crontab -l; cat /etc/cron.d/compactor-cron | crontab; crontab -l)
 
-COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+COPY supervisord.conf /supervisord.conf
 COPY master.sh /
 COPY runTasks.py /
 

--- a/docker/images/docker-spark/master/master.sh
+++ b/docker/images/docker-spark/master/master.sh
@@ -21,14 +21,14 @@ if curl --fail -X POST --output /dev/null --silent --head http://127.0.0.1:8080;
      printf 'Waiting for Spark Master...'
      until $(curl --output /dev/null --silent --head --fail http://127.0.0.1:8080); do
           printf '.'
-          sleep 5
+          sleep 1
      done
 fi
 
 ## Supervisor will monitor the ingestion to ensure it stays up
 supervisord -c /supervisord.conf
 
-export SPARK_MASTER_IP=`hostname`
+export SPARK_MASTER_HOST=`hostname`
 
 . "/spark/sbin/spark-config.sh"
 
@@ -37,6 +37,6 @@ export SPARK_MASTER_IP=`hostname`
 mkdir -p $SPARK_MASTER_LOG
 
 /spark/bin/spark-class org.apache.spark.deploy.master.Master \
-    --host $SPARK_MASTER_IP --port $SPARK_MASTER_PORT --webui-port $SPARK_MASTER_WEBUI_PORT >> $SPARK_MASTER_LOG/spark-master.out
+    --host $SPARK_MASTER_HOST --port $SPARK_MASTER_PORT --webui-port $SPARK_MASTER_WEBUI_PORT >> $SPARK_MASTER_LOG/spark-master.out
 
 

--- a/docker/images/docker-spark/master/master.sh
+++ b/docker/images/docker-spark/master/master.sh
@@ -25,21 +25,22 @@ if curl --fail -X POST --output /dev/null --silent --head http://127.0.0.1:8080;
 fi
 
 echo "Executing Clueso Pipeline in background..."
+
+supervisord -c /etc/supervisor/supervisord.conf -n
+
 # TODO put something to restart java pipeline in case this fails (non 0 return code)
-java -cp /spark/conf:/spark/jars/* \
-     -Xmx512m org.apache.spark.deploy.SparkSubmit \
-     --conf spark.executor.memory=512m \
-     --conf spark.driver.memory=512m \
-     --conf spark.master=spark://spark-master:7077 \
-     --conf spark.driver.cores=1 \
-     --conf spark.cores.max=2 \
-     --conf spark.executor.cores=1 \
-     --queue default \
-     --class com.scality.clueso.MetadataIngestionPipeline \
-     --name "Clueso Metadata Ingestion Pipeline" \
-     file:///clueso/lib/clueso.jar /clueso/conf/application.conf &
-
-
+#java -cp /spark/conf:/spark/jars/* \
+#     -Xmx512m org.apache.spark.deploy.SparkSubmit \
+#     --conf spark.executor.memory=512m \
+#     --conf spark.driver.memory=512m \
+#     --conf spark.master=spark://spark-master:7077 \
+#     --conf spark.driver.cores=1 \
+#     --conf spark.cores.max=2 \
+#     --conf spark.executor.cores=1 \
+#     --queue default \
+#     --class com.scality.clueso.MetadataIngestionPipeline \
+#     --name "Clueso Metadata Ingestion Pipeline" \
+#     file:///clueso/lib/clueso.jar /clueso/conf/application.conf &
 
 export SPARK_MASTER_IP=`hostname`
 

--- a/docker/images/docker-spark/master/master.sh
+++ b/docker/images/docker-spark/master/master.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
 # s3 secret credentials for Zenko
 if [ -r /run/secrets/s3-credentials ] ; then
@@ -24,23 +25,8 @@ if curl --fail -X POST --output /dev/null --silent --head http://127.0.0.1:8080;
      done
 fi
 
-echo "Executing Clueso Pipeline in background..."
-
-supervisord -c /etc/supervisor/supervisord.conf -n
-
-# TODO put something to restart java pipeline in case this fails (non 0 return code)
-#java -cp /spark/conf:/spark/jars/* \
-#     -Xmx512m org.apache.spark.deploy.SparkSubmit \
-#     --conf spark.executor.memory=512m \
-#     --conf spark.driver.memory=512m \
-#     --conf spark.master=spark://spark-master:7077 \
-#     --conf spark.driver.cores=1 \
-#     --conf spark.cores.max=2 \
-#     --conf spark.executor.cores=1 \
-#     --queue default \
-#     --class com.scality.clueso.MetadataIngestionPipeline \
-#     --name "Clueso Metadata Ingestion Pipeline" \
-#     file:///clueso/lib/clueso.jar /clueso/conf/application.conf &
+## Supervisor will monitor the ingestion to ensure it stays up
+supervisord -c /supervisord.conf
 
 export SPARK_MASTER_IP=`hostname`
 

--- a/docker/images/docker-spark/master/supervisord.conf
+++ b/docker/images/docker-spark/master/supervisord.conf
@@ -1,0 +1,25 @@
+[supervisord]
+
+[program:ingestion]
+command=/usr/bin/java -cp /spark/conf:/spark/jars/*
+     -Xmx512m org.apache.spark.deploy.SparkSubmit
+     --conf spark.executor.memory=512m
+     --conf spark.driver.memory=512m
+     --conf spark.master=spark://spark-master:7077
+     --conf spark.driver.cores=1
+     --conf spark.cores.max=2
+     --conf spark.executor.cores=1
+     --queue default
+     --class com.scality.clueso.MetadataIngestionPipeline
+     --name 'Clueso Metadata Ingestion Pipeline'
+     file:///clueso/lib/clueso.jar /clueso/conf/application.conf
+directory=/
+autostart=true
+autorestart=true
+process_name=metadata_ingestion
+numprocs=1
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+stderr_logfile=/dev/fd/2
+stderr_logfile_maxbytes=0
+stopsignal=QUIT

--- a/docker/images/docker-spark/master/supervisord.conf
+++ b/docker/images/docker-spark/master/supervisord.conf
@@ -22,4 +22,3 @@ stdout_logfile=/dev/fd/1
 stdout_logfile_maxbytes=0
 stderr_logfile=/dev/fd/2
 stderr_logfile_maxbytes=0
-stopsignal=QUIT

--- a/docker/images/docker-spark/worker/Dockerfile
+++ b/docker/images/docker-spark/worker/Dockerfile
@@ -1,9 +1,6 @@
-FROM scality/clueso-spark-base:hadoop2.8
+FROM scality/clueso-spark-base:latest
 
 HEALTHCHECK CMD curl -f http://localhost:8081/ || exit 1
-
-RUN apt-get update && \
-    apt-get install -y netcat
 
 COPY worker.sh /
 RUN chmod +x /worker.sh

--- a/docker/images/docker-spark/worker/Dockerfile
+++ b/docker/images/docker-spark/worker/Dockerfile
@@ -2,6 +2,9 @@ FROM scality/clueso-spark-base:hadoop2.8
 
 HEALTHCHECK CMD curl -f http://localhost:8081/ || exit 1
 
+RUN apt-get update && \
+    apt-get install -y netcat
+
 COPY worker.sh /
 RUN chmod +x /worker.sh
 

--- a/docker/images/docker-spark/worker/worker.sh
+++ b/docker/images/docker-spark/worker/worker.sh
@@ -6,5 +6,18 @@
 
   mkdir -p $SPARK_WORKER_LOG
 
+# wait for Spark Master to be live
+echo "Waiting for Spark Master to launch on 7077..."
+
+while ! nc -z spark-master 7077 &>/dev/null; do   
+  echo "Cannot contact spark master on 7077"
+  exit 1
+done
+
+echo "Spark Master Ready"
+sleep 3
+echo "Starting Spark Worker"
+
+# start Spark Worker
   /spark/sbin/../bin/spark-class org.apache.spark.deploy.worker.Worker \
     --webui-port $SPARK_WORKER_WEBUI_PORT $SPARK_MASTER >> $SPARK_WORKER_LOG/spark-worker.out

--- a/docker/images/docker-spark/worker/worker.sh
+++ b/docker/images/docker-spark/worker/worker.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -eo pipefail
 
   . "/spark/sbin/spark-config.sh"
 
@@ -6,18 +7,13 @@
 
   mkdir -p $SPARK_WORKER_LOG
 
-# wait for Spark Master to be live
-echo "Waiting for Spark Master to launch on 7077..."
-
-while ! nc -z spark-master 7077 &>/dev/null; do   
+# exit if spark master is not ready
+if [ ! nc -z spark-master 7077 &>/dev/null ]; then   
   echo "Cannot contact spark master on 7077"
   exit 1
-done
+fi
 
-echo "Spark Master Ready"
-sleep 3
 echo "Starting Spark Worker"
-
 # start Spark Worker
   /spark/sbin/../bin/spark-class org.apache.spark.deploy.worker.Worker \
     --webui-port $SPARK_WORKER_WEBUI_PORT $SPARK_MASTER >> $SPARK_WORKER_LOG/spark-worker.out

--- a/docker/images/docker-spark/worker/worker.sh
+++ b/docker/images/docker-spark/worker/worker.sh
@@ -7,13 +7,20 @@ set -eo pipefail
 
   mkdir -p $SPARK_WORKER_LOG
 
-# exit if spark master is not ready
-if [ ! nc -z spark-master 7077 &>/dev/null ]; then   
-  echo "Cannot contact spark master on 7077"
-  exit 1
-fi
+# Wait for spark master
+# This allows clean startup
+RETRY=15
+echo "Waiting for spark master"
+while ! nc -z spark-master 7077 &>/dev/null ; do
+  RETRY=$((RETRY-1))
+  if [ $RETRY == 0 ]; then
+    echo "Cannot contact spark master on 7077"
+    exit 1
+  fi
+  sleep 1
+done
 
 echo "Starting Spark Worker"
 # start Spark Worker
   /spark/sbin/../bin/spark-class org.apache.spark.deploy.worker.Worker \
-    --webui-port $SPARK_WORKER_WEBUI_PORT $SPARK_MASTER >> $SPARK_WORKER_LOG/spark-worker.out
+    --webui-port $SPARK_WORKER_WEBUI_PORT $SPARK_MASTER_HOST >> $SPARK_WORKER_LOG/spark-worker.out


### PR DESCRIPTION
Stability changes:
- Livy and Workers wait for Spark-master to load up before starting
- Improved inter-docker communication with changes to the Java DNS caching
- Ingestion is setup to restart on failure

Cleanups made to Dockerfiles, resources, and converted to using the :latest tag for building the images