### PR TITLE
FIX: Cache should return newest df

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ until the results for that file arrive.
 It assumes the docker stack is running (via docker-compose or docker swarm).
 
 This evaluates both query speed and latency, which may vary depending if cache is enabled and depending on 
-`cache_expiry` in Clueso configuration.
+`landing_cache_expiry` in Clueso configuration.
 
 Results can be published to Graphite and can be visualized using Grafana.
   

--- a/docker/images/docker-spark/base/application.conf
+++ b/docker/images/docker-spark/base/application.conf
@@ -20,8 +20,7 @@ bucket_staging_path = /staging
 
 # cache settings
 cache_dataframes = true
-clean_past_cache_delay = 2 minute
-cache_expiry = 60 seconds
+landing_cache_expiry = 60 seconds
 
 ############
 # Pipeline #
@@ -40,7 +39,6 @@ kafka_topic = "backbeat"
 # Compactor #
 #############
 
-# compaction – this should be longer than session lifetime (e.g. 1 hour)
 landing_purge_tolerance = 1 hour
 
 # graphite params

--- a/src/main/scala/com/scality/clueso/CluesoConfig.scala
+++ b/src/main/scala/com/scality/clueso/CluesoConfig.scala
@@ -37,7 +37,7 @@ class CluesoConfig(config: Config) {
   // compaction
   //    as S3 object store is eventual consistency, this sets a minimum 'age' for landing files
   //    to be deleted, avoiding data loss on compaction operation
-  def landingPurgeTolerance = config.getDuration("landing_purge_tolerance")
+  def landingPurgeTolerance = config.getDuration("landing_purge_tolerance").toMillis
 
 
   // pipeline settings
@@ -51,9 +51,8 @@ class CluesoConfig(config: Config) {
 
   // cache settings
   def cacheDataframes = config.hasPath("cache_dataframes") && config.getBoolean("cache_dataframes")
-  def cacheExpiry = config.getDuration("cache_expiry")
-  // controls after how much time should we evict the oldest cache, after finish a new computation
-  def cleanPastCacheDelay = config.getDuration("clean_past_cache_delay")
+  def landingCacheExpiry = config.getDuration("landing_cache_expiry").toMillis
+  def stagingCacheExpiry = Math.min(landingPurgeTolerance - 1000, landingCacheExpiry)
 
   // graphite metrics settings
   def graphiteHost = envOrElseConfig("graphite.hostname")

--- a/src/main/scala/com/scality/clueso/compact/TableFilesCompactor.scala
+++ b/src/main/scala/com/scality/clueso/compact/TableFilesCompactor.scala
@@ -105,6 +105,7 @@ class TableFilesCompactor(spark : SparkSession, implicit val config: CluesoConfi
     * @param subPartToRemove list of maxOpIndex to remove
     */
   def removeSubpartitionsFromLanding(landingPartitionPath: String, subPartToRemove: Array[String]): Unit = {
+    logger.info(s"Removing subpartitions from landing: ${landingPartitionPath}")
     val subpartitionPaths = fs.listStatus(new Path(landingPartitionPath), new PathFilter {
       override def accept(path: Path): Boolean = {
         // selects all the directories that follow the pattern K=V and with V present in   subPartToCompact   param
@@ -172,9 +173,8 @@ class TableFilesCompactor(spark : SparkSession, implicit val config: CluesoConfi
 
           logger.info(s"Successfully compacted bucket=$bucketNameValue")
 
-          logger.info(s"Waiting ${config.landingPurgeTolerance.toMillis}ms before purging compacted partitions")
-          Thread.sleep(config.landingPurgeTolerance.toMillis)
-
+          logger.info(s"Waiting ${config.landingPurgeTolerance}ms before purging compacted partitions")
+          Thread.sleep(config.landingPurgeTolerance)
           removeSubpartitionsFromLanding(landingPartitionPath, subPartToCompact)
         } else {
           logger.info("No subpartitions to compact.")

--- a/src/main/scala/com/scality/clueso/query/cache/SessionCacheManager.scala
+++ b/src/main/scala/com/scality/clueso/query/cache/SessionCacheManager.scala
@@ -1,25 +1,23 @@
 package com.scality.clueso.query.cache
 
-import java.util.Date
 import java.util.concurrent.atomic.AtomicReference
 
-import com.scality.clueso.CluesoConfig
+import com.scality.clueso.{CluesoConfig, PathUtils}
 import com.scality.clueso.query.MetadataQueryExecutor.setupDf
 import com.typesafe.scalalogging.LazyLogging
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.joda.time.DateTime
 
-import scala.concurrent.ExecutionContext.Implicits.global
-import scala.concurrent.Future
 
 object SessionCacheManager extends LazyLogging {
   var bucketDfs = Map[String, AtomicReference[DataFrame]]()
-  var bucketUpdateTs = Map[String, DateTime]()
+  var bucketLandingUpdateTs = Map[String, DateTime]()
+  var bucketStagingUpdateTs = Map[String, DateTime]()
 
   val setupDfLock = new scala.collection.parallel.mutable.ParHashSet[String]()
 
   def getCachedBucketDataframe(spark: SparkSession, bucketName: String)(implicit config: CluesoConfig): DataFrame = {
-    val tableView = s"${new Date().getTime}_${bucketName.replace("-","_").replace(".","__")}"
+    val tableView = s"${bucketName.replace("-","_").replace(".","__")}"
 
     // check if cache doesn't exist
     if (!bucketDfs.contains(bucketName)) {
@@ -31,7 +29,8 @@ object SessionCacheManager extends LazyLogging {
         bucketDf.sparkSession.catalog.cacheTable(tableView)
 
         bucketDfs = bucketDfs.updated(bucketName, new AtomicReference(bucketDf))
-        bucketUpdateTs = bucketUpdateTs.updated(bucketName, DateTime.now())
+        bucketLandingUpdateTs = bucketLandingUpdateTs.updated(bucketName, DateTime.now())
+        bucketStagingUpdateTs = bucketStagingUpdateTs.updated(bucketName, DateTime.now())
         releaseLock(bucketName)
       }
       logger.info(s"Cache does not exist. Created cache for $bucketName")
@@ -39,33 +38,22 @@ object SessionCacheManager extends LazyLogging {
     } else {
       logger.info(s"Cache exists for ${bucketName}")
       // cache exists
-      if (bucketUpdateTs(bucketName).plus(config.cacheExpiry.toMillis).isBeforeNow) {
-        logger.info(s"Cache too old for ${bucketName}. Recalculating if can acquire lock.")
+      if (bucketLandingUpdateTs(bucketName).plus(config.landingCacheExpiry).isBeforeNow ||
+        bucketStagingUpdateTs(bucketName).plus(config.stagingCacheExpiry).isBeforeNow) {
+        logger.info(s"Cache too old for ${bucketName}. Refreshing landing if can acquire lock.")
         // check if there's a dataframe update going on
         if (acquireLock(bucketName)) {
-          logger.info(s"Acquired lock. Calculating view $tableView")
-          // calculating view by recalculating staging as well (otherwise, we will constantly accumulate cache based on prior)
-          val bucketDf = setupDf(spark, config, bucketName)
-          bucketDf.createOrReplaceTempView(tableView)
-
-          // this operation triggers execution
-          bucketDf.sparkSession.catalog.cacheTable(tableView)
+          logger.info(s"Acquired lock. Refreshing landing path ${PathUtils.landingURI}=${bucketName}/")
           // to remove spark metadata
           spark.catalog.refreshTable(tableView)
-          logger.info(s"Atomically swapping DF for bucket = $bucketName ( new = $tableView )")
-          val oldDf = bucketDfs.getOrElse(bucketName, new AtomicReference()).getAndSet(bucketDf)
-          bucketUpdateTs = bucketUpdateTs.updated(bucketName, DateTime.now())
-          releaseLock(bucketName) // unlock
-
-          Future {
-            logger.info(s"Async calling sleep to unpersist old df for ${bucketName}")
-            // sleep before deleting oldDf
-            val sleepDuration = config.cleanPastCacheDelay.toMillis
-            logger.info(s"Sleeping cleanPastCacheDelay = $sleepDuration ms")
-            Thread.sleep(sleepDuration)
-            logger.info(s"Unpersisting ${oldDf.rdd.id} for $bucketName after having slept $sleepDuration ms")
-            oldDf.unpersist(true)
+          spark.catalog.refreshByPath(s"/${PathUtils.landingURI}=${bucketName}/")
+          bucketLandingUpdateTs = bucketLandingUpdateTs.updated(bucketName, DateTime.now())
+          if (bucketStagingUpdateTs(bucketName).plus(config.stagingCacheExpiry).isBeforeNow) {
+            logger.info(s"Also refreshing staging path ${PathUtils.stagingURI}=${bucketName}/")
+            spark.catalog.refreshByPath(s"/${PathUtils.stagingURI}=${bucketName}/")
+            bucketStagingUpdateTs = bucketStagingUpdateTs.updated(bucketName, DateTime.now())
           }
+          releaseLock(bucketName) // unlock
         }
       }
       //  return most recent cached version (always)

--- a/src/main/scala/com/scality/clueso/query/cache/SessionCacheManager.scala
+++ b/src/main/scala/com/scality/clueso/query/cache/SessionCacheManager.scala
@@ -26,6 +26,7 @@ object SessionCacheManager extends LazyLogging {
       val bucketDf = setupDf(spark, config, bucketName)
 
       if (acquireLock(bucketName)) {
+        logger.info(s"Cache does not exist. Creating tableView: $tableView")
         bucketDf.createOrReplaceTempView(tableView)
         bucketDf.sparkSession.catalog.cacheTable(tableView)
 
@@ -43,15 +44,14 @@ object SessionCacheManager extends LazyLogging {
         // check if there's a dataframe update going on
         if (acquireLock(bucketName)) {
           logger.info(s"Acquired lock. Calculating view $tableView")
-          val bucketDf = setupDf(spark, config, bucketName, bucketDfs(bucketName).get())
-
+          // calculating view by recalculating staging as well (otherwise, we will constantly accumulate cache based on prior)
+          val bucketDf = setupDf(spark, config, bucketName)
           bucketDf.createOrReplaceTempView(tableView)
 
           // this operation triggers execution
           bucketDf.sparkSession.catalog.cacheTable(tableView)
-
-          logger.info(s"Calculating view $tableView")
-          bucketDf.count() // force calculation
+          // to remove spark metadata
+          spark.catalog.refreshTable(tableView)
           logger.info(s"Atomically swapping DF for bucket = $bucketName ( new = $tableView )")
           val oldDf = bucketDfs.getOrElse(bucketName, new AtomicReference()).getAndSet(bucketDf)
           bucketUpdateTs = bucketUpdateTs.updated(bucketName, DateTime.now())
@@ -63,7 +63,7 @@ object SessionCacheManager extends LazyLogging {
             val sleepDuration = config.cleanPastCacheDelay.toMillis
             logger.info(s"Sleeping cleanPastCacheDelay = $sleepDuration ms")
             Thread.sleep(sleepDuration)
-            logger.info(s"Unpersisting ${oldDf} for $bucketName after having slept $sleepDuration ms")
+            logger.info(s"Unpersisting ${oldDf.rdd.id} for $bucketName after having slept $sleepDuration ms")
             oldDf.unpersist(true)
           }
         }

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -3,13 +3,13 @@ spark_ui_port = 4040
 
 # storage params
 s3_ssl_enabled = false
-s3_endpoint = "http://127.0.0.1"
+s3_endpoint = "http://127.0.0.1:8000"
 s3_path_style_access = true
 checkpoint_path = /spark_checkpoint
 
 # read from environment vars
-aws_access_key_id = ""
-aws_secret_access_key = ""
+aws_access_key_id = "accessKey1"
+aws_secret_access_key = "verySecretKey1"
 
 # locations
 bucket_name = "METADATA"
@@ -21,9 +21,8 @@ bucket_staging_path = /staging
 ##############
 # cache settings
 cache_dataframes = false
-clean_past_cache_delay = 60 seconds
-cache_expiry = 30 seconds
-spark_sql_print_explain = false
+landing_cache_expiry = 30 seconds
+spark_sql_print_explain = true
 
 ############
 # Pipeline #
@@ -43,7 +42,7 @@ kafka_topic = "backbeat"
 #############
 
 # compaction
-landing_purge_tolerance = 4 seconds
+landing_purge_tolerance = 10 seconds
 
 
 # graphite params

--- a/src/test/resources/application.conf
+++ b/src/test/resources/application.conf
@@ -19,11 +19,10 @@ bucket_staging_path = /staging
 ##############
 # Query Exec #
 ##############
-# TODO  unit test the cache and ensure we got correct results, and cached is recomputed after X amount of time
 # cache settings
 cache_dataframes = false
-clean_past_cache_delay = 2 minute
-cache_expiry = 60 seconds
+clean_past_cache_delay = 60 seconds
+cache_expiry = 30 seconds
 spark_sql_print_explain = false
 
 ############

--- a/src/test/scala/com/scality/clueso/CacheSpec.scala
+++ b/src/test/scala/com/scality/clueso/CacheSpec.scala
@@ -16,24 +16,51 @@ class CacheSpec extends WordSpec with Matchers with SparkContextSetup {
         fs.mkdirs(new Path(PathUtils.stagingURI))
         fs.mkdirs(new Path(PathUtils.landingURI))
         fs.mkdirs(new Path(PathUtils.landingURI concat("/bucket=") concat(bucketName)))
-        val df = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
-        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs df
-        df.count() shouldBe 0
 
         // populate landing
         val numberParquetFiles = "10"
+        val originalEntries = "15"
         val configPath = getClass.getResource("/application.conf").toString.substring(5)
-        LandingMetadataPopulatorTool.main(Array(configPath, bucketName, "10", numberParquetFiles))
+        LandingMetadataPopulatorTool.main(Array(configPath, bucketName, originalEntries, numberParquetFiles))
 
-        // wait to update cache
+        val df = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs df
+        df.count() shouldBe originalEntries.toInt
+
+        // populate landing again
+        val updatedEntries = "10"
+        LandingMetadataPopulatorTool.main(Array(configPath, bucketName, updatedEntries, numberParquetFiles))
+
+        // checking that retrieve stale data from cache since cache has not expired
+        val staleDf = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs df
+        staleDf.count() shouldBe originalEntries.toInt
+
+        // wait for cache to update
         val wait = config.cacheExpiry.toMillis + 1000
         logger.info(s"Sleeping so cache expires for $wait ms")
         Thread.sleep(wait)
 
+        // updated cache should only have new entries
         val updatedDf = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
-        updatedDf.count shouldEqual 10
-        SessionCacheManager.bucketDfs(bucketName).get().count() shouldEqual 10
+        updatedDf.count shouldEqual (updatedEntries.toInt)
+        SessionCacheManager.bucketDfs(bucketName).get().count() shouldEqual (updatedEntries.toInt)
         SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs updatedDf
+
+        // wait to clean up old cache (also means current cache will expire)
+        val cleanupWait = config.cleanPastCacheDelay.toMillis + 3000
+        logger.info(s"Sleeping to wait for old cache cleanup for $cleanupWait ms")
+        Thread.sleep(cleanupWait)
+
+        // repopulate landing again
+        val newNumberParquetFiles = "11"
+        val newEntries = "11"
+        LandingMetadataPopulatorTool.main(Array(configPath, bucketName, newEntries, newNumberParquetFiles))
+
+        // should be able to calculate cache again even though an old cache has been deleted
+        val retryDf = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+        SessionCacheManager.bucketDfs(bucketName).get().count() shouldEqual (newEntries.toInt)
+        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs retryDf
 
     }
   }

--- a/src/test/scala/com/scality/clueso/CacheSpec.scala
+++ b/src/test/scala/com/scality/clueso/CacheSpec.scala
@@ -1,0 +1,40 @@
+package com.scality.clueso
+
+import com.scality.clueso.query.cache.SessionCacheManager
+import com.scality.clueso.query.cache.SessionCacheManager.logger
+import com.scality.clueso.tools.LandingMetadataPopulatorTool
+import org.apache.hadoop.fs.Path
+import org.scalatest.{Matchers, WordSpec}
+
+class CacheSpec extends WordSpec with Matchers with SparkContextSetup {
+  "SessionCacheManager" should {
+    "Scenario 1: cache dataframe and return dataframe" in withSparkContext {
+      (spark, config) =>
+        val bucketName = "cachebucket"
+        val fs = SparkUtils.buildHadoopFs(config)
+        implicit val _config = config
+        fs.mkdirs(new Path(PathUtils.stagingURI))
+        fs.mkdirs(new Path(PathUtils.landingURI))
+        fs.mkdirs(new Path(PathUtils.landingURI concat("/bucket=") concat(bucketName)))
+        val df = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs df
+        df.count() shouldBe 0
+
+        // populate landing
+        val numberParquetFiles = "10"
+        val configPath = getClass.getResource("/application.conf").toString.substring(5)
+        LandingMetadataPopulatorTool.main(Array(configPath, bucketName, "10", numberParquetFiles))
+
+        // wait to update cache
+        val wait = config.cacheExpiry.toMillis + 1000
+        logger.info(s"Sleeping so cache expires for $wait ms")
+        Thread.sleep(wait)
+
+        val updatedDf = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+        updatedDf.count shouldEqual 10
+        SessionCacheManager.bucketDfs(bucketName).get().count() shouldEqual 10
+        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs updatedDf
+
+    }
+  }
+}

--- a/src/test/scala/com/scality/clueso/CacheSpec.scala
+++ b/src/test/scala/com/scality/clueso/CacheSpec.scala
@@ -1,7 +1,7 @@
 package com.scality.clueso
 
+import com.scality.clueso.compact.TableFilesCompactor
 import com.scality.clueso.query.cache.SessionCacheManager
-import com.scality.clueso.query.cache.SessionCacheManager.logger
 import com.scality.clueso.tools.LandingMetadataPopulatorTool
 import org.apache.hadoop.fs.Path
 import org.scalatest.{Matchers, WordSpec}
@@ -37,8 +37,8 @@ class CacheSpec extends WordSpec with Matchers with SparkContextSetup {
         staleDf.count() shouldBe originalEntries.toInt
 
         // wait for cache to update
-        val wait = config.cacheExpiry.toMillis + 1000
-        logger.info(s"Sleeping so cache expires for $wait ms")
+        val wait = config.landingCacheExpiry + 1000
+        logger.info(s"Sleeping so cache expires: $wait ms")
         Thread.sleep(wait)
 
         // updated cache should only have new entries
@@ -47,10 +47,9 @@ class CacheSpec extends WordSpec with Matchers with SparkContextSetup {
         SessionCacheManager.bucketDfs(bucketName).get().count() shouldEqual (updatedEntries.toInt)
         SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs updatedDf
 
-        // wait to clean up old cache (also means current cache will expire)
-        val cleanupWait = config.cleanPastCacheDelay.toMillis + 3000
-        logger.info(s"Sleeping to wait for old cache cleanup for $cleanupWait ms")
-        Thread.sleep(cleanupWait)
+        // wait for cache to expire again
+        logger.info(s"Sleeping so cache expires: $wait ms")
+        Thread.sleep(wait)
 
         // repopulate landing again
         val newNumberParquetFiles = "11"
@@ -61,6 +60,48 @@ class CacheSpec extends WordSpec with Matchers with SparkContextSetup {
         val retryDf = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
         SessionCacheManager.bucketDfs(bucketName).get().count() shouldEqual (newEntries.toInt)
         SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs retryDf
+
+    }
+    "Scenario 2: cache properly after compaction" in withSparkContext {
+      (spark, config) =>
+        val bucketName = "compactioncachebucket"
+        val fs = SparkUtils.buildHadoopFs(config)
+        implicit val _config = config
+        fs.mkdirs(new Path(PathUtils.stagingURI))
+        fs.mkdirs(new Path(PathUtils.landingURI))
+        fs.mkdirs(new Path(PathUtils.landingURI concat("/bucket=") concat(bucketName)))
+
+        // populate landing
+        val numberParquetFiles = "10"
+        val originalEntries = "15"
+        val configPath = getClass.getResource("/application.conf").toString.substring(5)
+        LandingMetadataPopulatorTool.main(Array(configPath, bucketName, originalEntries, numberParquetFiles))
+
+        val df = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs df
+        df.count() shouldBe originalEntries.toInt
+
+        // compact files from landing to staging (calling this causes process to wait for landingPurgeTolerance time)
+        // so both landing and staging cache should have expired by then
+        val compactor = new TableFilesCompactor(spark, config)
+        compactor.compactLandingPartition("bucket", bucketName, 1, true)
+
+        // checking that retrieve same data in different format from cache since cache expired
+        val updatedDf = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs updatedDf
+        updatedDf.count() shouldBe originalEntries.toInt
+
+//        // wait for landing cache to update
+//        val wait = config.landingCacheExpiry + 1000
+//        logger.info(s"Sleeping so cache expires: $wait ms")
+//        Thread.sleep(wait)
+
+//        // updated cache should have no entries since we artificially
+//        val updatedDf = SessionCacheManager.getCachedBucketDataframe(spark, bucketName)(config)
+//        updatedDf.count shouldEqual (updatedEntries.toInt)
+//        SessionCacheManager.bucketDfs(bucketName).get().count() shouldEqual (updatedEntries.toInt)
+//        SessionCacheManager.bucketDfs(bucketName).get() should be theSameInstanceAs updatedDf
+//
 
     }
   }

--- a/src/test/scala/com/scality/clueso/CluesoMergingAndQueryingSpec.scala
+++ b/src/test/scala/com/scality/clueso/CluesoMergingAndQueryingSpec.scala
@@ -323,7 +323,6 @@ class CluesoMergingAndQueryingSpec extends WordSpec with Matchers with SparkCont
         // then
         result.count() shouldBe 0
 
-
         // given we apply merge
         val compactor = new TableFilesCompactor(spark, config)
         compactor.compactLandingPartition("bucket", randomBucketName, 1, force = true)


### PR DESCRIPTION
Prior logic resulted in returning old df on search
and only updating cache async.

Now we return updated results if cache expired.